### PR TITLE
Add support to ignore lines during the parse

### DIFF
--- a/src/main/java/com/sonalake/utah/Parser.java
+++ b/src/main/java/com/sonalake/utah/Parser.java
@@ -93,34 +93,40 @@ public class Parser {
       boolean wasDelimMatched = false;
       while (!isRecordLoaded) {
         String currentLine = reader.readLine();
-        if (null == currentLine) {
-          isReaderFinished = true;
-          isRecordLoaded = true;
+        boolean shouldIgnoreLine = config.isIgnorable(currentLine);
+
+        if (shouldIgnoreLine) {
+          continue;
         } else {
-          if (StringUtils.isNotBlank(previousDelim)) {
-            buffer.append(previousDelim + "\n");
-            previousDelim = "";
-          }
-          if (isSelectingHeader && config.matchesHeaderDelim(currentLine)) {
+          if (null == currentLine) {
+            isReaderFinished = true;
             isRecordLoaded = true;
-          } else if (!isSelectingHeader && config.matchesRecordDelim(currentLine)) {
-            Delimiter applicableDelim = config.getApplicableDelim(currentLine);
-            // if the delimiter says we're at the start of the record,
-            // and this is the first record, we need to treat it differently
-            boolean isFirstDelimOfInterest = 0 == recordNumber && !wasDelimMatched;
-            if (applicableDelim.isDelimAtStartOfRecord() && isFirstDelimOfInterest) {
-              // this is the first record, so we don't stop here
-              wasDelimMatched = true;
-            } else {
-              if (applicableDelim.isRetainDelim()) {
-                previousDelim = currentLine;
-              }
+          } else {
+            if (StringUtils.isNotBlank(previousDelim)) {
+              buffer.append(previousDelim + "\n");
+              previousDelim = "";
+            }
+            if (isSelectingHeader && config.matchesHeaderDelim(currentLine)) {
               isRecordLoaded = true;
+            } else if (!isSelectingHeader && config.matchesRecordDelim(currentLine)) {
+              Delimiter applicableDelim = config.getApplicableDelim(currentLine);
+              // if the delimiter says we're at the start of the record,
+              // and this is the first record, we need to treat it differently
+              boolean isFirstDelimOfInterest = 0 == recordNumber && !wasDelimMatched;
+              if (applicableDelim.isDelimAtStartOfRecord() && isFirstDelimOfInterest) {
+                // this is the first record, so we don't stop here
+                wasDelimMatched = true;
+              } else {
+                if (applicableDelim.isRetainDelim()) {
+                  previousDelim = currentLine;
+                }
+                isRecordLoaded = true;
+              }
             }
           }
-        }
-        if (StringUtils.isNotBlank(currentLine)) {
-          buffer.append(currentLine + "\n");
+          if (StringUtils.isNotBlank(currentLine)) {
+            buffer.append(currentLine + "\n");
+          }
         }
       }
       if (isReaderFinished && buffer.length() == 0) {

--- a/src/main/java/com/sonalake/utah/config/Config.java
+++ b/src/main/java/com/sonalake/utah/config/Config.java
@@ -50,6 +50,13 @@ public class Config {
   protected List<ValueRegex> values;
 
   /**
+   * Lines to be ignored
+   */
+  @XmlElement(name = "ignore")
+  protected List<Ignorer> ignores;
+
+
+  /**
    * Precompile the patterns, but only do it the once.
    */
   void compilePatterns() {
@@ -61,6 +68,12 @@ public class Config {
     }
     for (Delimiter delimiter : delimiters) {
       delimiter.compile(searches);
+    }
+
+    if (null != ignores) {
+      for (Ignorer ignorer : ignores) {
+        ignorer.compile(searches);
+      }    
     }
   }
 
@@ -148,6 +161,24 @@ public class Config {
     }
     return true;
   }
+
+  /**
+   * Validates if the line should be ignored
+   *
+   * @return true if the line is ignored during the record build
+   */
+  public boolean isIgnorable(String candidate) {
+    if (null == candidate || null == ignores || ignores.isEmpty()) {
+      return false;
+    } else {
+      for (Ignorer ignorer : ignores) {
+        if (ignorer.matches(candidate)) {
+          return true;
+        }        
+      }
+    }
+    return false;
+  }  
 
   /**
    * Get the applicable delimiter for the candidate. The first delimiter that matches the  text as used.

--- a/src/main/java/com/sonalake/utah/config/Ignorer.java
+++ b/src/main/java/com/sonalake/utah/config/Ignorer.java
@@ -1,0 +1,38 @@
+package com.sonalake.utah.config;
+
+import javax.xml.bind.annotation.XmlValue;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * A header delimiter - used to identify the header where there are values in the header of the file that are to be
+ * added to every record.
+ */
+public class Ignorer {
+
+  /**
+   * Raw delimiter string from the config file
+   */
+  @XmlValue
+  protected String delimiter;
+
+  /**
+   * The compiled pattern, this is the one used at runtime
+   */
+  private Pattern compiledPattern;
+
+  public boolean matches(String candidate) {
+    return compiledPattern.matcher(candidate).matches();
+  }
+
+  /**
+   * Compile the delimiter based on the searches
+   *
+   * @param searches the searches, processed in this order
+   */
+  void compile(List<NameValue> searches) {
+    String valueText = SearchHelper.translate(delimiter, searches);
+    compiledPattern = Pattern.compile(".*?" + valueText + ".*?");
+  }
+
+}


### PR DESCRIPTION
To address my need to from issue #8 this was the most basic and easy to solve the problem and still keep the spirit of the library.

I have add a support for multiples `<ignore>regex</ignore>` tags. This way now we have ability to entire skip undesired lines from the file.