### PR TITLE
skip GPG on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ sudo: false
 jdk:
 - openjdk11
 install: true
-script: mvn  --settings .travis/settings.xml deploy
+script:
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash mvn  --settings .travis/settings.xml deploy -DskipGpgSign=true; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash mvn  --settings .travis/settings.xml deploy; fi'
+
 before_install:
-- openssl aes-256-cbc -K $encrypted_426140d7796a_key -iv $encrypted_426140d7796a_iv
-  -in .travis/gpg-rings.tgz.enc -out .travis/gpg-rings.tgz -d
-- tar -xf .travis/gpg-rings.tgz -C .travis/
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash openssl aes-256-cbc -K $encrypted_426140d7796a_key -iv $encrypted_426140d7796a_iv -in .travis/gpg-rings.tgz.enc -out .travis/gpg-rings.tgz -d; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash tar -xf .travis/gpg-rings.tgz -C .travis/; fi'
 after_success:
 - mvn --settings .travis/settings.xml clean test jacoco:report coveralls:report
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ jdk:
 - openjdk11
 install: true
 script:
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash mvn  --settings .travis/settings.xml deploy -DskipGpgSign=true; fi'
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash mvn  --settings .travis/settings.xml deploy; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then mvn  --settings .travis/settings.xml deploy -DskipGpgSign=true; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then mvn  --settings .travis/settings.xml deploy; fi'
 
 before_install:
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash openssl aes-256-cbc -K $encrypted_426140d7796a_key -iv $encrypted_426140d7796a_iv -in .travis/gpg-rings.tgz.enc -out .travis/gpg-rings.tgz -d; fi'
-- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash tar -xf .travis/gpg-rings.tgz -C .travis/; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_426140d7796a_key -iv $encrypted_426140d7796a_iv -in .travis/gpg-rings.tgz.enc -out .travis/gpg-rings.tgz -d; fi'
+- 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then tar -xf .travis/gpg-rings.tgz -C .travis/; fi'
 after_success:
 - mvn --settings .travis/settings.xml clean test jacoco:report coveralls:report
 notifications:


### PR DESCRIPTION
PRs won't have access to the keys, so skip GPG signing (not a problem - we won't be releasing these jars)