### PR TITLE
Bumped JUnit version to address vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -119,6 +120,7 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>javax.xml.bind</groupId>
@@ -171,7 +173,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>[4.13.1,)</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Vulnerability [details](https://github.com/sonalake/utah-parser/network/alert/pom.xml/junit:junit/open).
Bumped JaCoCo and Coveralls maven plugin versions to remove build warning.